### PR TITLE
Add SalesChannelContext to CleverPushWorkerJsController

### DIFF
--- a/src/Storefront/Controller/CleverPushWorkerJsController.php
+++ b/src/Storefront/Controller/CleverPushWorkerJsController.php
@@ -3,6 +3,7 @@
 namespace CleverPush\CleverPushShopware\Storefront\Controller;
 
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Controller\StorefrontController;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
@@ -20,9 +21,9 @@ class CleverPushWorkerJsController extends StorefrontController
     }
 
     #[Route(path: '/cleverpush-worker.js', name: 'frontend.cleverpush.worker', defaults: ['_httpCache' => true], methods: ['GET'])]
-    public function showCleverPushWorkerJs(): Response
+    public function showCleverPushWorkerJs(SalesChannelContext $salesChannelContext): Response
     {
-        $channelId = trim($this->systemConfigService->getString('CleverPushShopwarePlugin.config.channelId'));
+        $channelId = trim($this->systemConfigService->getString('CleverPushShopwarePlugin.config.channelId', $salesChannelContext->getSalesChannelId()));
 
         $content = 'console.log(\'CleverPush Channel ID is not configured.\');';
         if ($channelId !== '' && $channelId !== '0') {


### PR DESCRIPTION
This pull request updates the `CleverPushWorkerJsController` to ensure that the CleverPush Channel ID is retrieved in a sales channel–aware manner. This improves the controller's ability to serve the correct configuration based on the current sales channel context.

Key changes:

**Sales Channel Context Integration:**
* The `showCleverPushWorkerJs` method now accepts a `SalesChannelContext` parameter, enabling sales channel–specific logic.
* The CleverPush Channel ID is now fetched using the current sales channel's ID, ensuring the correct configuration is used for each sales channel.

**Dependency Import:**
* Added an import for `SalesChannelContext` to support type hinting in the controller method.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small controller change; behavior shifts to sales-channel-specific config lookup which could change which worker script is served in multi-channel setups.
> 
> **Overview**
> `/cleverpush-worker.js` now receives `SalesChannelContext` and uses it to fetch `CleverPushShopwarePlugin.config.channelId` scoped to the current sales channel.
> 
> This changes the generated worker script to be **sales-channel aware** rather than using the global system config value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdfebbec8ce941a36f96409b06ca23336d23733a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the CleverPush worker JS controller sales channel–aware so it returns the correct Channel ID per sales channel. Fixes incorrect config in multi-channel setups.

- **Bug Fixes**
  - `showCleverPushWorkerJs` now accepts `SalesChannelContext` and reads `CleverPushShopwarePlugin.config.channelId` using the current sales channel ID.
  - Added `SalesChannelContext` import for type hinting.

<sup>Written for commit bdfebbec8ce941a36f96409b06ca23336d23733a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

