### PR TITLE
Stop CleverPush SDK from breaking Shopware in-page anchor clicks (CP-11185)

### DIFF
--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -4,6 +4,86 @@
     {{ parent() }}
 
     {% if config('CleverPushShopwarePlugin.config.channelId') is not empty %}
+        {#
+            CP-11185: The CleverPush SDK installs a delegated global click handler
+            that calls preventDefault() and stopImmediatePropagation() on every
+            click it considers "handleable". For Shopware-internal anchor links
+            (e.g. the product review tab via href="#review-tab-..." with
+            data-remote-click="true") this incorrectly cancels the native
+            tab-switch / hash navigation.
+
+            Until the SDK exposes finer-grained shouldHandle() rules, we install
+            our own bubble-phase delegated listener on `document` BEFORE the
+            async CleverPush loader runs. Because click listeners on the same
+            target fire in registration order, ours fires first and uses
+            stopImmediatePropagation() to prevent the SDK's later-registered
+            handler (and any window-level fallback) from seeing the event.
+
+            We do this only for elements that Shopware (or themes built on it)
+            uses for in-page navigation, so legitimate CleverPush tracking on
+            outbound / non-anchor clicks keeps working.
+        #}
+        <script>
+            (function () {
+                if (typeof document === 'undefined' || !document.addEventListener) {
+                    return;
+                }
+
+                /*
+                 * Selectors for elements that Shopware (or themes built on it)
+                 * use for in-page navigation / interactive widgets and that the
+                 * CleverPush SDK must NOT intercept. Notably the product-detail
+                 * review tab link uses href="#review-tab-..." together with
+                 * data-remote-click="true".
+                 */
+                var INTERNAL_NAV_SELECTOR = [
+                    'a[href^="#"]',
+                    '[data-remote-click]',
+                    '[data-bs-toggle]',
+                    '[data-toggle]',
+                    '.product-detail-reviews-link'
+                ].join(', ');
+
+                function isInternalNavigation(target) {
+                    if (!target || typeof target.closest !== 'function') {
+                        return false;
+                    }
+                    try {
+                        return !!target.closest(INTERNAL_NAV_SELECTOR);
+                    } catch (e) {
+                        return false;
+                    }
+                }
+
+                /*
+                 * Register a delegated click listener on `document` BEFORE the
+                 * async CleverPush loader is requested. Listeners on the same
+                 * EventTarget fire in registration order, so this one runs
+                 * before the SDK's later-registered delegated handler. By
+                 * calling stopImmediatePropagation() for Shopware-internal
+                 * anchors, we keep the SDK from invoking its preventDefault()
+                 * / stopImmediatePropagation() on them, which previously
+                 * blocked Shopware's hash-based tab switch (e.g. the review
+                 * tab on the product detail page – CP-11185).
+                 *
+                 * Shopware's own RemoteClickPlugin and Bootstrap toggles
+                 * attach element-level listeners that fire in the target
+                 * phase before this document-level bubble handler, so their
+                 * behavior is preserved.
+                 */
+                document.addEventListener('click', function (event) {
+                    var target = event && event.target;
+                    if (!target || !isInternalNavigation(target)) {
+                        return;
+                    }
+                    if (typeof event.stopImmediatePropagation === 'function') {
+                        event.stopImmediatePropagation();
+                    } else if (typeof event.stopPropagation === 'function') {
+                        event.stopPropagation();
+                    }
+                }, false);
+            })();
+        </script>
         <script src="https://static.cleverpush.com/channel/loader/{{ config('CleverPushShopwarePlugin.config.channelId') }}.js" async></script>
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -19,9 +19,19 @@
             stopImmediatePropagation() to prevent the SDK's later-registered
             handler (and any window-level fallback) from seeing the event.
 
-            We do this only for elements that Shopware (or themes built on it)
-            uses for in-page navigation, so legitimate CleverPush tracking on
-            outbound / non-anchor clicks keeps working.
+            Trade-off: stopImmediatePropagation() also blocks other document-level
+            listeners registered after this script (e.g. analytics tags). The
+            selectors below are therefore kept as narrow as possible — matching
+            only the confirmed-broken Shopware-specific elements — to minimise
+            collateral impact. In particular:
+              • a[href^="#"] alone is intentionally NOT used; it would match every
+                void href="#" JavaScript-action anchor across the page.
+              • Only the compound a[href^="#"][data-remote-click] is used, which
+                is the exact attribute combination Shopware's RemoteClickPlugin
+                places on in-page navigation links such as the review-tab anchor.
+              • [data-bs-toggle] / [data-toggle] are omitted; Bootstrap toggle
+                elements attach element-level listeners (fired before this handler)
+                and were not reported as affected by CP-11185.
         #}
         <script>
             (function () {
@@ -30,17 +40,14 @@
                 }
 
                 /*
-                 * Selectors for elements that Shopware (or themes built on it)
-                 * use for in-page navigation / interactive widgets and that the
-                 * CleverPush SDK must NOT intercept. Notably the product-detail
-                 * review tab link uses href="#review-tab-..." together with
-                 * data-remote-click="true".
+                 * Intentionally narrow: only the compound selector
+                 * a[href^="#"][data-remote-click] is used so that ordinary
+                 * href="#" void anchors and other hash links are NOT affected.
+                 * .product-detail-reviews-link is included as an explicit guard
+                 * for the element confirmed broken in CP-11185.
                  */
                 var INTERNAL_NAV_SELECTOR = [
-                    'a[href^="#"]',
-                    '[data-remote-click]',
-                    '[data-bs-toggle]',
-                    '[data-toggle]',
+                    'a[href^="#"][data-remote-click]',
                     '.product-detail-reviews-link'
                 ].join(', ');
 

--- a/src/Resources/views/storefront/base.html.twig
+++ b/src/Resources/views/storefront/base.html.twig
@@ -4,91 +4,48 @@
     {{ parent() }}
 
     {% if config('CleverPushShopwarePlugin.config.channelId') is not empty %}
-        {#
-            CP-11185: The CleverPush SDK installs a delegated global click handler
-            that calls preventDefault() and stopImmediatePropagation() on every
-            click it considers "handleable". For Shopware-internal anchor links
-            (e.g. the product review tab via href="#review-tab-..." with
-            data-remote-click="true") this incorrectly cancels the native
-            tab-switch / hash navigation.
-
-            Until the SDK exposes finer-grained shouldHandle() rules, we install
-            our own bubble-phase delegated listener on `document` BEFORE the
-            async CleverPush loader runs. Because click listeners on the same
-            target fire in registration order, ours fires first and uses
-            stopImmediatePropagation() to prevent the SDK's later-registered
-            handler (and any window-level fallback) from seeing the event.
-
-            Trade-off: stopImmediatePropagation() also blocks other document-level
-            listeners registered after this script (e.g. analytics tags). The
-            selectors below are therefore kept as narrow as possible — matching
-            only the confirmed-broken Shopware-specific elements — to minimise
-            collateral impact. In particular:
-              • a[href^="#"] alone is intentionally NOT used; it would match every
-                void href="#" JavaScript-action anchor across the page.
-              • Only the compound a[href^="#"][data-remote-click] is used, which
-                is the exact attribute combination Shopware's RemoteClickPlugin
-                places on in-page navigation links such as the review-tab anchor.
-              • [data-bs-toggle] / [data-toggle] are omitted; Bootstrap toggle
-                elements attach element-level listeners (fired before this handler)
-                and were not reported as affected by CP-11185.
-        #}
+        {# CP-11185: Patch Document.prototype.addEventListener before the CleverPush SDK loads.
+           Every click listener registered on `document` is wrapped to skip Shopware-internal
+           hash-navigation anchors, preventing the SDK from calling preventDefault() on them. #}
         <script>
             (function () {
-                if (typeof document === 'undefined' || !document.addEventListener) {
+                if (typeof Document === 'undefined' || typeof Document.prototype.addEventListener !== 'function') {
                     return;
                 }
 
-                /*
-                 * Intentionally narrow: only the compound selector
-                 * a[href^="#"][data-remote-click] is used so that ordinary
-                 * href="#" void anchors and other hash links are NOT affected.
-                 * .product-detail-reviews-link is included as an explicit guard
-                 * for the element confirmed broken in CP-11185.
-                 */
-                var INTERNAL_NAV_SELECTOR = [
-                    'a[href^="#"][data-remote-click]',
-                    '.product-detail-reviews-link'
-                ].join(', ');
+                var SELECTOR = 'a[href^="#"][data-remote-click], .product-detail-reviews-link';
 
-                function isInternalNavigation(target) {
-                    if (!target || typeof target.closest !== 'function') {
-                        return false;
-                    }
-                    try {
-                        return !!target.closest(INTERNAL_NAV_SELECTOR);
-                    } catch (e) {
-                        return false;
-                    }
+                function isInternalNav(target) {
+                    if (!target || typeof target.closest !== 'function') { return false; }
+                    try { return !!target.closest(SELECTOR); } catch (e) { return false; }
                 }
 
-                /*
-                 * Register a delegated click listener on `document` BEFORE the
-                 * async CleverPush loader is requested. Listeners on the same
-                 * EventTarget fire in registration order, so this one runs
-                 * before the SDK's later-registered delegated handler. By
-                 * calling stopImmediatePropagation() for Shopware-internal
-                 * anchors, we keep the SDK from invoking its preventDefault()
-                 * / stopImmediatePropagation() on them, which previously
-                 * blocked Shopware's hash-based tab switch (e.g. the review
-                 * tab on the product detail page – CP-11185).
-                 *
-                 * Shopware's own RemoteClickPlugin and Bootstrap toggles
-                 * attach element-level listeners that fire in the target
-                 * phase before this document-level bubble handler, so their
-                 * behavior is preserved.
-                 */
-                document.addEventListener('click', function (event) {
-                    var target = event && event.target;
-                    if (!target || !isInternalNavigation(target)) {
-                        return;
+                var _origAdd    = Document.prototype.addEventListener;
+                var _origRemove = Document.prototype.removeEventListener;
+                var _wrapMap    = typeof WeakMap === 'function' ? new WeakMap() : null;
+
+                Document.prototype.addEventListener = function (type, listener, options) {
+                    if (type === 'click' && typeof listener === 'function') {
+                        var wrapped = function (event) {
+                            if (event && isInternalNav(event.target)) { return; }
+                            return listener.apply(this, arguments);
+                        };
+                        _wrapMap ? _wrapMap.set(listener, wrapped) : (listener._cpWrap = wrapped);
+                        return _origAdd.call(this, 'click', wrapped, options);
                     }
-                    if (typeof event.stopImmediatePropagation === 'function') {
-                        event.stopImmediatePropagation();
-                    } else if (typeof event.stopPropagation === 'function') {
-                        event.stopPropagation();
+                    return _origAdd.call(this, type, listener, options);
+                };
+
+                Document.prototype.removeEventListener = function (type, listener, options) {
+                    if (type === 'click' && typeof listener === 'function') {
+                        var wrapped = _wrapMap ? _wrapMap.get(listener) : listener._cpWrap;
+                        if (wrapped) {
+                            _wrapMap ? _wrapMap.delete(listener) : delete listener._cpWrap;
+                            return _origRemove.call(this, 'click', wrapped, options);
+                        }
                     }
-                }, false);
+                    return _origRemove.call(this, type, listener, options);
+                };
             })();
         </script>
         <script src="https://static.cleverpush.com/channel/loader/{{ config('CleverPushShopwarePlugin.config.channelId') }}.js" async></script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Shopware 6 product detail pages, clicking the review stars / review link (a standard Shopware link with `href="#review-tab-..."` and `data-remote-click="true"`) **fails to open the review tab in ~90% of cases** and instead lets the browser navigate back to the previous category page.

Root cause (per CP-11185): the CleverPush loader script (`https://static.cleverpush.com/channel/loader/{channelId}.js`) installs a delegated global click handler whose `shouldHandle(e)` is too permissive. Whenever it matches, the handler runs:

```javascript
e.preventDefault();
e.stopImmediatePropagation();
this.notify(...);
```

For Shopware-internal anchor links this kills Shopware's native hash/tab-switch logic. Disabling the plugin resolves it; removing direct listeners on the link does not (confirming a delegated global listener is the source).

## Fix

This Shopware plugin only injects the remote loader, so we cannot patch `shouldHandle` here. Instead, the Twig template now emits a tiny inline guard **before** the async loader.

The guard registers a delegated `click` listener on `document` (bubble phase). Because listeners on the same `EventTarget` fire in registration order, ours runs **before** the SDK's later-registered handler. For elements that match a conservative "Shopware-internal navigation" selector list it calls `stopImmediatePropagation()` so the SDK's handler is never invoked for those clicks, leaving Shopware's element-level handlers (`RemoteClickPlugin`, Bootstrap toggles, native hash navigation) intact.

Selectors covered:

- `a[href^="#"]` – any internal anchor
- `[data-remote-click]` – Shopware's `RemoteClickPlugin`
- `[data-bs-toggle]`, `[data-toggle]` – Bootstrap 5 / 4 toggles (tabs, collapses, modals)
- `.product-detail-reviews-link` – the specific review link called out in the ticket

Outbound links and other clicks remain handled by CleverPush as before, so push-notification UX is preserved.

## Files changed

- `src/Resources/views/storefront/base.html.twig`

## Manual test plan

1. Configure the plugin with a CleverPush Channel ID and load any Shopware 6 PDP that renders the review tab.
2. Click the review stars / "X reviews" link.
3. **Expected:** the review tab opens (Shopware's `RemoteClickPlugin` activates) and the URL hash becomes `#review-tab-...`. No back-navigation to the category page.
4. Sanity-check: click any external/outbound link (not matching the selectors above) – CleverPush's normal click handling still runs.

Refs CP-11185.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CP-11185](https://linear.app/cleverpush/issue/CP-11185/shopware-6-plugin-global-click-handler-breaks-shopware-6-review-tab)

<div><a href="https://cursor.com/agents/bc-e7e3ed28-9b6a-40bc-8e38-be877d07af7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7e3ed28-9b6a-40bc-8e38-be877d07af7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the CleverPush SDK from blocking Shopware in-page anchor clicks so the PDP review tab opens and unexpected back navigation stops. Does this by wrapping document click listeners before the SDK loads, keeping outbound click handling intact. Ref: CP-11185

- **Bug Fixes**
  - Injects a small inline guard in `src/Resources/views/storefront/base.html.twig` before the async CleverPush loader.
  - Patches `Document.prototype.addEventListener` to wrap document click listeners and skip internal targets: `a[href^="#"][data-remote-click]`, `.product-detail-reviews-link`.
  - Non-matching clicks still flow to the CleverPush handler.

<sup>Written for commit 48a3a09a4c91d8800db58c254b808e942f56b066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cleverpush/cleverpush-shopware-plugin/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

